### PR TITLE
fix: track pos cursor and send last_pos on reconnect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ dist/
 coverage/
 .DS_Store
 *.log
+specs

--- a/biome.json
+++ b/biome.json
@@ -30,5 +30,30 @@
 	},
 	"files": {
 		"ignore": ["node_modules", "dist", "coverage", "*.d.ts", "*.d.cts"]
-	}
+	},
+	"overrides": [
+		{
+			"include": ["**/*.svelte", "**/*.vue"],
+			"linter": {
+				"rules": {
+					"correctness": {
+						"noUnusedVariables": "off"
+					},
+					"style": {
+						"useConst": "off"
+					}
+				}
+			}
+		},
+		{
+			"include": ["**/*.test.ts", "**/*.test.tsx", "**/*.spec.ts", "**/*.spec.tsx"],
+			"linter": {
+				"rules": {
+					"suspicious": {
+						"noExplicitAny": "off"
+					}
+				}
+			}
+		}
+	]
 }

--- a/examples/chat-react/src/components/App.tsx
+++ b/examples/chat-react/src/components/App.tsx
@@ -1,10 +1,10 @@
-import { SukkoClient } from "@sukko/sdk";
 import { SukkoProvider } from "@sukko/react";
+import { SukkoClient } from "@sukko/sdk";
 import { WebSocketTransport } from "@sukko/websocket";
 import { useCallback, useRef, useState } from "react";
 import type { ChatMessage } from "../utils";
-import { ConnectionPanel } from "./ConnectionPanel";
 import { ChannelSidebar } from "./ChannelSidebar";
+import { ConnectionPanel } from "./ConnectionPanel";
 import { MessageFeed } from "./MessageFeed";
 import { MessageInput } from "./MessageInput";
 
@@ -74,11 +74,7 @@ export function App() {
 					/>
 					<div className="message-feed">
 						<MessageFeed messages={messages} onMessage={addMessage} />
-						<MessageInput
-							token={token}
-							selectedChannel={selectedChannel}
-							onMessage={addMessage}
-						/>
+						<MessageInput token={token} selectedChannel={selectedChannel} onMessage={addMessage} />
 					</div>
 				</div>
 			</SukkoProvider>
@@ -89,7 +85,15 @@ export function App() {
 		<>
 			{connectionPanel}
 			<div className="main-layout">
-				<div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center", color: "#8b949e" }}>
+				<div
+					style={{
+						flex: 1,
+						display: "flex",
+						alignItems: "center",
+						justifyContent: "center",
+						color: "#8b949e",
+					}}
+				>
 					Enter a WebSocket URL and token, then click Connect.
 				</div>
 			</div>

--- a/examples/chat-react/src/components/ChannelSidebar.tsx
+++ b/examples/chat-react/src/components/ChannelSidebar.tsx
@@ -33,7 +33,13 @@ function SubscribedChannel(props: {
 		>
 			<span className="channel-name">{props.channel}</span>
 			{props.action && (
-				<button type="button" onClick={(e) => { e.stopPropagation(); props.action!.onClick(); }}>
+				<button
+					type="button"
+					onClick={(e) => {
+						e.stopPropagation();
+						props.action!.onClick();
+					}}
+				>
 					{props.action.label}
 				</button>
 			)}
@@ -50,19 +56,25 @@ export function ChannelSidebar(props: {
 	const client = useSukkoClient();
 	const claims = useMemo(() => decodeTokenPayload(props.token), [props.token]);
 
-	const publicChannels = ["all.trade"];
-	const userChannels = claims.sub ? [`notifications.${claims.sub}`] : [];
+	const publicChannels = useMemo(() => ["all.trade"], []);
+	const userChannels = useMemo(
+		() => (claims.sub ? [`notifications.${claims.sub}`] : []),
+		[claims.sub],
+	);
 	const availableGroups = claims.groups ?? [];
 	const [joinedGroups, setJoinedGroups] = useState<string[]>([]);
 
-	const allSubscribed = [...publicChannels, ...userChannels, ...joinedGroups.map((g) => `community.${g}`)];
+	const allSubscribed = useMemo(
+		() => [...publicChannels, ...userChannels, ...joinedGroups.map((g) => `community.${g}`)],
+		[publicChannels, userChannels, joinedGroups],
+	);
 
 	// Auto-select first channel
 	useEffect(() => {
 		if (!props.selectedChannel && allSubscribed.length > 0) {
 			props.onSelectChannel(allSubscribed[0]);
 		}
-	}, [allSubscribed.length]);
+	}, [props.selectedChannel, props.onSelectChannel, allSubscribed]);
 
 	const handleJoinGroup = (group: string) => {
 		if (!joinedGroups.includes(group)) {

--- a/examples/chat-react/src/components/ConnectionPanel.tsx
+++ b/examples/chat-react/src/components/ConnectionPanel.tsx
@@ -39,7 +39,12 @@ export function ConnectionPanel(props: {
 					Disconnect
 				</button>
 			) : (
-				<button type="button" className="btn-connect" onClick={props.onConnect} disabled={!props.token}>
+				<button
+					type="button"
+					className="btn-connect"
+					onClick={props.onConnect}
+					disabled={!props.token}
+				>
 					Connect
 				</button>
 			)}

--- a/examples/chat-react/src/components/MessageFeed.tsx
+++ b/examples/chat-react/src/components/MessageFeed.tsx
@@ -10,11 +10,12 @@ export function MessageFeed(props: {
 	const listRef = useRef<HTMLDivElement>(null);
 
 	// Auto-scroll to bottom on new messages
+	// biome-ignore lint/correctness/useExhaustiveDependencies: props.messages intentionally triggers scroll; listRef is a stable ref
 	useEffect(() => {
 		if (listRef.current) {
 			listRef.current.scrollTop = listRef.current.scrollHeight;
 		}
-	}, [props.messages.length]);
+	}, [props.messages]);
 
 	// Capture error events as system messages
 	useSukkoEvent("error", (err) => {

--- a/examples/chat-react/src/components/MessageInput.tsx
+++ b/examples/chat-react/src/components/MessageInput.tsx
@@ -36,7 +36,7 @@ export function MessageInput(props: {
 		});
 
 		setText("");
-	}, [canSend, text, props.selectedChannel, client, props.onMessage]);
+	}, [canSend, text, props.selectedChannel, props.token, client, props.onMessage]);
 
 	const handleRefreshToken = useCallback(async () => {
 		const newToken = prompt("Enter new JWT token:");
@@ -68,9 +68,7 @@ export function MessageInput(props: {
 	return (
 		<>
 			<div className="input-bar">
-				{props.selectedChannel && (
-					<span className="channel-label">{props.selectedChannel}</span>
-				)}
+				{props.selectedChannel && <span className="channel-label">{props.selectedChannel}</span>}
 				<input
 					type="text"
 					value={text}
@@ -84,10 +82,20 @@ export function MessageInput(props: {
 				</button>
 			</div>
 			<div className="action-bar">
-				<button type="button" className="btn-secondary" onClick={handleRefreshToken} disabled={!isConnected}>
+				<button
+					type="button"
+					className="btn-secondary"
+					onClick={handleRefreshToken}
+					disabled={!isConnected}
+				>
 					Refresh Token
 				</button>
-				<button type="button" className="btn-secondary" onClick={handleReplay} disabled={!isConnected}>
+				<button
+					type="button"
+					className="btn-secondary"
+					onClick={handleReplay}
+					disabled={!isConnected}
+				>
 					Reconnect with Replay
 				</button>
 			</div>

--- a/examples/chat-svelte/src/App.svelte
+++ b/examples/chat-svelte/src/App.svelte
@@ -2,11 +2,9 @@
 import { SukkoClient } from "@sukko/sdk";
 import { WebSocketTransport } from "@sukko/websocket";
 import type { ChatMessage } from "./utils";
-import ConnectionPanel from "./components/ConnectionPanel.svelte";
-import ChatLayout from "./components/ChatLayout.svelte";
 
-let wsUrl = $state("ws://localhost:3000/ws");
-let token = $state("");
+const wsUrl = $state("ws://localhost:3000/ws");
+const token = $state("");
 let client = $state<SukkoClient | null>(null);
 let messages = $state<ChatMessage[]>([]);
 let selectedChannel = $state<string | null>(null);

--- a/examples/chat-svelte/src/components/ChannelSidebar.svelte
+++ b/examples/chat-svelte/src/components/ChannelSidebar.svelte
@@ -11,7 +11,7 @@ interface Props {
 	onMessage: (msg: ChatMessage) => void;
 }
 
-let { token, selectedChannel, onSelectChannel, onMessage }: Props = $props();
+const { token, selectedChannel, onSelectChannel, onMessage }: Props = $props();
 
 const client = getSukkoClient();
 let joinedGroups = $state<string[]>([]);

--- a/examples/chat-svelte/src/components/ChatLayout.svelte
+++ b/examples/chat-svelte/src/components/ChatLayout.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
 import type { SukkoClient } from "@sukko/sdk";
-import { setSukkoClient, createConnectionState } from "@sukko/svelte";
+import { createConnectionState, setSukkoClient } from "@sukko/svelte";
 import type { ChatMessage } from "../utils";
-import ConnectionPanel from "./ConnectionPanel.svelte";
-import ChannelSidebar from "./ChannelSidebar.svelte";
-import MessageFeed from "./MessageFeed.svelte";
-import MessageInput from "./MessageInput.svelte";
 
 interface Props {
 	client: SukkoClient;
@@ -21,10 +17,18 @@ interface Props {
 	onMessage: (msg: ChatMessage) => void;
 }
 
-let {
-	client, wsUrl, token, messages, selectedChannel,
-	onWsUrlChange, onTokenChange, onConnect, onDisconnect,
-	onSelectChannel, onMessage,
+const {
+	client,
+	wsUrl,
+	token,
+	messages,
+	selectedChannel,
+	onWsUrlChange,
+	onTokenChange,
+	onConnect,
+	onDisconnect,
+	onSelectChannel,
+	onMessage,
 }: Props = $props();
 
 // Set context during component initialization — this is the correct place
@@ -32,10 +36,10 @@ setSukkoClient(client);
 
 // Now we can safely use context-dependent stores
 const connectionStore = createConnectionState();
-let connectionState = $state("disconnected");
+let _connectionState = $state("disconnected");
 
-const unsubConnection = connectionStore.subscribe((v) => {
-	connectionState = v.state;
+const _unsubConnection = connectionStore.subscribe((v) => {
+	_connectionState = v.state;
 });
 </script>
 

--- a/examples/chat-svelte/src/components/ConnectionPanel.svelte
+++ b/examples/chat-svelte/src/components/ConnectionPanel.svelte
@@ -10,7 +10,16 @@ interface Props {
 	onDisconnect: () => void;
 }
 
-let { wsUrl, token, connected, connectionState, onWsUrlChange, onTokenChange, onConnect, onDisconnect }: Props = $props();
+const {
+	wsUrl,
+	token,
+	connected,
+	connectionState,
+	onWsUrlChange,
+	onTokenChange,
+	onConnect,
+	onDisconnect,
+}: Props = $props();
 </script>
 
 <div class="connection-bar">

--- a/examples/chat-svelte/src/components/MessageFeed.svelte
+++ b/examples/chat-svelte/src/components/MessageFeed.svelte
@@ -2,14 +2,14 @@
 import { onSukkoEvent } from "@sukko/svelte";
 import { tick } from "svelte";
 import type { ChatMessage } from "../utils";
-import { createMessageId, formatTimestamp } from "../utils";
+import { createMessageId } from "../utils";
 
 interface Props {
 	messages: ChatMessage[];
 	onMessage: (msg: ChatMessage) => void;
 }
 
-let { messages, onMessage }: Props = $props();
+const { messages, onMessage }: Props = $props();
 
 let listEl: HTMLDivElement;
 

--- a/examples/chat-svelte/src/components/MessageInput.svelte
+++ b/examples/chat-svelte/src/components/MessageInput.svelte
@@ -9,14 +9,14 @@ interface Props {
 	onMessage: (msg: ChatMessage) => void;
 }
 
-let { token, selectedChannel, onMessage }: Props = $props();
+const { token, selectedChannel, onMessage }: Props = $props();
 
 const client = getSukkoClient();
 const connectionStore = createConnectionState();
 let isConnected = $state(false);
 let text = $state("");
 
-const unsubConnection = connectionStore.subscribe((v) => {
+const _unsubConnection = connectionStore.subscribe((v) => {
 	isConnected = v.isConnected;
 });
 

--- a/examples/chat-vue/src/App.vue
+++ b/examples/chat-vue/src/App.vue
@@ -1,19 +1,14 @@
 <script setup lang="ts">
 import { SukkoClient } from "@sukko/sdk";
-import { SukkoProvider } from "@sukko/vue";
 import { WebSocketTransport } from "@sukko/websocket";
 import { ref, shallowRef } from "vue";
 import type { ChatMessage } from "./utils";
-import ConnectionPanel from "./components/ConnectionPanel.vue";
-import ChannelSidebar from "./components/ChannelSidebar.vue";
-import MessageFeed from "./components/MessageFeed.vue";
-import MessageInput from "./components/MessageInput.vue";
 
 const wsUrl = ref("ws://localhost:3000/ws");
 const token = ref("");
 const client = shallowRef<SukkoClient | null>(null);
 const messages = ref<ChatMessage[]>([]);
-const selectedChannel = ref<string | null>(null);
+const _selectedChannel = ref<string | null>(null);
 
 function addMessage(msg: ChatMessage) {
 	messages.value = [...messages.value, msg].slice(-200);

--- a/examples/chat-vue/src/components/ChannelSidebar.vue
+++ b/examples/chat-vue/src/components/ChannelSidebar.vue
@@ -21,7 +21,7 @@ const publicChannels = ["all.trade"];
 const userChannels = computed(() =>
 	claims.value.sub ? [`notifications.${claims.value.sub}`] : [],
 );
-const availableGroups = computed(() => claims.value.groups ?? []);
+const _availableGroups = computed(() => claims.value.groups ?? []);
 const joinedGroups = ref<string[]>([]);
 const groupChannels = computed(() => joinedGroups.value.map((g) => `community.${g}`));
 
@@ -48,11 +48,15 @@ const { lastMessage } = useSubscription<Record<string, unknown>>({
 });
 
 // Auto-select first channel
-watch(allSubscribed, (channels) => {
-	if (!props.selectedChannel && channels.length > 0) {
-		emit("selectChannel", channels[0]);
-	}
-}, { immediate: true });
+watch(
+	allSubscribed,
+	(channels) => {
+		if (!props.selectedChannel && channels.length > 0) {
+			emit("selectChannel", channels[0]);
+		}
+	},
+	{ immediate: true },
+);
 
 function joinGroup(group: string) {
 	if (!joinedGroups.value.includes(group)) {

--- a/examples/chat-vue/src/components/ConnectionPanel.vue
+++ b/examples/chat-vue/src/components/ConnectionPanel.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
-import StatusIndicator from "./StatusIndicator.vue";
-
-const props = defineProps<{
+const _props = defineProps<{
 	wsUrl: string;
 	token: string;
 	connected: boolean;
 }>();
 
-const emit = defineEmits<{
+const _emit = defineEmits<{
 	"update:wsUrl": [url: string];
 	"update:token": [token: string];
 	connect: [];

--- a/examples/chat-vue/src/components/MessageFeed.vue
+++ b/examples/chat-vue/src/components/MessageFeed.vue
@@ -2,7 +2,7 @@
 import { useSukkoEvent } from "@sukko/vue";
 import { nextTick, ref, watch } from "vue";
 import type { ChatMessage } from "../utils";
-import { createMessageId, formatTimestamp } from "../utils";
+import { createMessageId } from "../utils";
 
 const props = defineProps<{
 	messages: ChatMessage[];
@@ -15,12 +15,15 @@ const emit = defineEmits<{
 const listRef = ref<HTMLDivElement>();
 
 // Auto-scroll on new messages
-watch(() => props.messages.length, async () => {
-	await nextTick();
-	if (listRef.value) {
-		listRef.value.scrollTop = listRef.value.scrollHeight;
-	}
-});
+watch(
+	() => props.messages.length,
+	async () => {
+		await nextTick();
+		if (listRef.value) {
+			listRef.value.scrollTop = listRef.value.scrollHeight;
+		}
+	},
+);
 
 useSukkoEvent("error", (err) => {
 	emit("message", {

--- a/examples/chat-vue/src/components/MessageInput.vue
+++ b/examples/chat-vue/src/components/MessageInput.vue
@@ -17,7 +17,9 @@ const client = useSukkoClient();
 const { isConnected } = useConnectionState();
 const text = ref("");
 
-const canSend = computed(() => isConnected.value && !!props.selectedChannel && text.value.trim().length > 0);
+const canSend = computed(
+	() => isConnected.value && !!props.selectedChannel && text.value.trim().length > 0,
+);
 
 function handleSend() {
 	if (!canSend.value || !props.selectedChannel) return;

--- a/packages/react/src/context.tsx
+++ b/packages/react/src/context.tsx
@@ -1,8 +1,10 @@
 import { SukkoClient } from "@sukko/sdk";
 import type { SukkoClientOptions } from "@sukko/sdk";
-import { createContext, useEffect, useRef, type ReactNode } from "react";
+import { type ReactNode, createContext, useEffect, useRef } from "react";
 
-export const SukkoContext: React.Context<SukkoClient | null> = createContext<SukkoClient | null>(null);
+export const SukkoContext: React.Context<SukkoClient | null> = createContext<SukkoClient | null>(
+	null,
+);
 
 export interface SukkoProviderProps {
 	/** Pre-built client instance (takes precedence over options). */

--- a/packages/react/src/hooks/use-event.ts
+++ b/packages/react/src/hooks/use-event.ts
@@ -23,7 +23,7 @@ export function useSukkoEvent<K extends keyof SukkoClientEvents>(
 	useEffect(() => {
 		// biome-ignore lint/suspicious/noExplicitAny: wrapper must forward any args
 		const wrapper = (...args: any[]) => {
-			(handlerRef.current as Function)(...args);
+			(handlerRef.current as (...args: unknown[]) => void)(...args);
 		};
 
 		const off = client.on(event, wrapper as SukkoClientEvents[K]);

--- a/packages/react/src/hooks/use-subscription.ts
+++ b/packages/react/src/hooks/use-subscription.ts
@@ -57,6 +57,7 @@ export function useSubscription<T = unknown>(
 	const isSubscribed = useRef(false);
 
 	// Subscribe to external store (message updates)
+	// biome-ignore lint/correctness/useExhaustiveDependencies: channels is captured via channelKey which provides stable identity
 	const subscribe = useCallback(
 		(onStoreChange: () => void): (() => void) => {
 			const off = client.on("message", (msg: DataMessage) => {
@@ -84,6 +85,7 @@ export function useSubscription<T = unknown>(
 	const lastMessage = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
 	// Manage WebSocket subscriptions with ref counting
+	// biome-ignore lint/correctness/useExhaustiveDependencies: channels is captured via channelKey which provides stable identity
 	useEffect(() => {
 		if (!enabled || channels.length === 0) return;
 

--- a/packages/react/tests/use-connection.test.tsx
+++ b/packages/react/tests/use-connection.test.tsx
@@ -71,7 +71,9 @@ describe("useConnectionState", () => {
 		);
 
 		act(() => {
+			// biome-ignore lint/suspicious/noExplicitAny: test-only access to internal client state
 			(client as any)._state = "connected";
+			// biome-ignore lint/suspicious/noExplicitAny: test-only access to internal client state
 			(client as any).emit("stateChange", "connected");
 		});
 
@@ -90,7 +92,9 @@ describe("useConnectionState", () => {
 		);
 
 		act(() => {
+			// biome-ignore lint/suspicious/noExplicitAny: test-only access to internal client state
 			(client as any)._state = "reconnecting";
+			// biome-ignore lint/suspicious/noExplicitAny: test-only access to internal client state
 			(client as any).emit("stateChange", "reconnecting");
 		});
 

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -21,9 +21,7 @@ import type {
 	UnsubscriptionAckMessage,
 } from "./types";
 
-type ResolvedOptions = Required<
-	Omit<SukkoClientOptions, "transport" | "token" | "getToken">
-> & {
+type ResolvedOptions = Required<Omit<SukkoClientOptions, "transport" | "token" | "getToken">> & {
 	token: string;
 	getToken: SukkoClientOptions["getToken"];
 };
@@ -70,7 +68,7 @@ export class SukkoClient extends TypedEventEmitter<SukkoClientEvents> {
 
 	// Replay state
 	private clientId: string;
-	private lastOffsets = new Map<string, number>();
+	private lastPos = new Map<string, string>();
 	private lastActivityTimestamp: number = Date.now();
 
 	// Timers
@@ -236,18 +234,19 @@ export class SukkoClient extends TypedEventEmitter<SukkoClientEvents> {
 	// Public API — Replay
 	// ---------------------------------------------------------------------------
 
-	/** Send a reconnect-with-replay request using stored offsets. */
+	/** Send a reconnect-with-replay request using last-known pos values per channel. */
 	reconnectWithReplay(): void {
 		if (this.transport.state !== "open") return;
+		if (this.lastPos.size === 0) return;
 
-		const lastOffset: Record<string, number> = {};
-		this.lastOffsets.forEach((offset, topic) => {
-			lastOffset[topic] = offset;
+		const lastPos: Record<string, string> = {};
+		this.lastPos.forEach((pos, channel) => {
+			lastPos[channel] = pos;
 		});
 
 		this.send({
 			type: "reconnect",
-			data: { client_id: this.clientId, last_offset: lastOffset },
+			data: { client_id: this.clientId, last_pos: lastPos },
 		});
 	}
 
@@ -360,7 +359,9 @@ export class SukkoClient extends TypedEventEmitter<SukkoClientEvents> {
 			switch (raw.type) {
 				case "message": {
 					const msg = raw as unknown as DataMessage;
-					this.lastOffsets.set(msg.channel, msg.seq);
+					if (msg.pos) {
+						this.lastPos.set(msg.channel, msg.pos);
+					}
 					this.emit("message", msg);
 					break;
 				}

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -185,7 +185,10 @@ export class SukkoClient extends TypedEventEmitter<SukkoClientEvents> {
 
 	/** Unsubscribe from one or more channels. */
 	unsubscribe(channels: string[]): void {
-		for (const ch of channels) this._subscriptions.delete(ch);
+		for (const ch of channels) {
+			this._subscriptions.delete(ch);
+			this.lastPos.delete(ch);
+		}
 
 		if (this.transport.state === "open") {
 			this.send({ type: "unsubscribe", data: { channels } });

--- a/packages/sdk/src/emitter.ts
+++ b/packages/sdk/src/emitter.ts
@@ -9,7 +9,7 @@
 export type EventMap = { [K: string]: (...args: any[]) => void };
 
 export class TypedEventEmitter<T extends EventMap = EventMap> {
-	private listeners = new Map<keyof T, Set<Function>>();
+	private listeners = new Map<keyof T, Set<(...args: unknown[]) => void>>();
 
 	/**
 	 * Register an event listener. Returns an unsubscribe function.

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -2,7 +2,12 @@
 // Connection state
 // ---------------------------------------------------------------------------
 
-export type ConnectionState = "disconnected" | "connecting" | "connected" | "reconnecting" | "error";
+export type ConnectionState =
+	| "disconnected"
+	| "connecting"
+	| "connected"
+	| "reconnecting"
+	| "error";
 
 // ---------------------------------------------------------------------------
 // Client → Server messages
@@ -25,7 +30,7 @@ export interface PublishMessage {
 
 export interface ReconnectMessage {
 	type: "reconnect";
-	data: { client_id: string; last_offset: Record<string, number> };
+	data: { client_id: string; last_pos: Record<string, string> };
 }
 
 export interface HeartbeatMessage {
@@ -56,6 +61,7 @@ export interface DataMessage<T = unknown> {
 	ts: number;
 	channel: string;
 	data: T;
+	pos?: string;
 }
 
 export interface SubscriptionAckMessage {

--- a/packages/sdk/tests/client.test.ts
+++ b/packages/sdk/tests/client.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { SukkoClient } from "../src/client";
 import { CLOSE_CODES } from "../src/constants";
 import { TypedEventEmitter } from "../src/emitter";
-import type { Transport, TransportCapabilities, TransportEvents, TransportState } from "../src/transport";
+import type {
+	Transport,
+	TransportCapabilities,
+	TransportEvents,
+	TransportState,
+} from "../src/transport";
 
 // ---------------------------------------------------------------------------
 // Mock Transport
@@ -69,9 +74,10 @@ class MockTransport extends TypedEventEmitter<TransportEvents> implements Transp
 // Helpers
 // ---------------------------------------------------------------------------
 
-function createClient(
-	overrides: Partial<ConstructorParameters<typeof SukkoClient>[0]> = {},
-): { client: SukkoClient; transport: MockTransport } {
+function createClient(overrides: Partial<ConstructorParameters<typeof SukkoClient>[0]> = {}): {
+	client: SukkoClient;
+	transport: MockTransport;
+} {
 	const transport = (overrides.transport as MockTransport) ?? new MockTransport();
 	const client = new SukkoClient({
 		transport,
@@ -412,10 +418,7 @@ describe("SukkoClient", () => {
 			await vi.advanceTimersByTimeAsync(500); // would have timed out
 
 			// close should not have been called with heartbeat timeout
-			expect(closeSpy).not.toHaveBeenCalledWith(
-				CLOSE_CODES.HEARTBEAT_TIMEOUT,
-				"Heartbeat timeout",
-			);
+			expect(closeSpy).not.toHaveBeenCalledWith(CLOSE_CODES.HEARTBEAT_TIMEOUT, "Heartbeat timeout");
 
 			client.disconnect();
 		});
@@ -654,18 +657,19 @@ describe("SukkoClient", () => {
 	});
 
 	describe("replay", () => {
-		it("sends reconnect message with stored offsets", async () => {
+		it("sends reconnect message with last_pos when pos values are tracked", async () => {
 			const { client, transport } = createClient();
 			client.connect();
 			await vi.advanceTimersByTimeAsync(0);
 
-			// Simulate a message to populate offsets
+			// Simulate a message with pos to populate lastPos
 			transport.simulateMessage({
 				type: "message",
 				seq: 42,
 				ts: Date.now(),
 				channel: "tenant.BTC.trade",
 				data: { price: 50000 },
+				pos: "3-42",
 			});
 
 			client.reconnectWithReplay();
@@ -673,7 +677,7 @@ describe("SukkoClient", () => {
 			const reconnectMsg = transport.sent.find((s) => JSON.parse(s).type === "reconnect");
 			expect(reconnectMsg).toBeDefined();
 			const parsed = JSON.parse(reconnectMsg!);
-			expect(parsed.data.last_offset["tenant.BTC.trade"]).toBe(42);
+			expect(parsed.data.last_pos["tenant.BTC.trade"]).toBe("3-42");
 
 			client.disconnect();
 		});
@@ -682,6 +686,62 @@ describe("SukkoClient", () => {
 			const { client, transport } = createClient();
 			client.reconnectWithReplay();
 			expect(transport.sent.length).toBe(0);
+		});
+
+		it("does not send reconnect when no pos values have been tracked", async () => {
+			const { client, transport } = createClient();
+			client.connect();
+			await vi.advanceTimersByTimeAsync(0);
+
+			// Simulate a message WITHOUT pos (e.g. Direct backend)
+			transport.simulateMessage({
+				type: "message",
+				seq: 1,
+				ts: Date.now(),
+				channel: "tenant.BTC.trade",
+				data: { price: 50000 },
+			});
+
+			client.reconnectWithReplay();
+
+			const reconnectMsg = transport.sent.find((s) => JSON.parse(s).type === "reconnect");
+			expect(reconnectMsg).toBeUndefined();
+
+			client.disconnect();
+		});
+
+		it("only includes channels with pos in last_pos map", async () => {
+			const { client, transport } = createClient();
+			client.connect();
+			await vi.advanceTimersByTimeAsync(0);
+
+			// Channel with pos (Kafka backend)
+			transport.simulateMessage({
+				type: "message",
+				seq: 1,
+				ts: Date.now(),
+				channel: "tenant.BTC.trade",
+				data: {},
+				pos: "1-100",
+			});
+			// Channel without pos (Direct backend)
+			transport.simulateMessage({
+				type: "message",
+				seq: 2,
+				ts: Date.now(),
+				channel: "tenant.ETH.trade",
+				data: {},
+			});
+
+			client.reconnectWithReplay();
+
+			const reconnectMsg = transport.sent.find((s) => JSON.parse(s).type === "reconnect");
+			expect(reconnectMsg).toBeDefined();
+			const parsed = JSON.parse(reconnectMsg!);
+			expect(parsed.data.last_pos["tenant.BTC.trade"]).toBe("1-100");
+			expect(parsed.data.last_pos["tenant.ETH.trade"]).toBeUndefined();
+
+			client.disconnect();
 		});
 	});
 });

--- a/packages/sdk/tests/client.test.ts
+++ b/packages/sdk/tests/client.test.ts
@@ -743,5 +743,43 @@ describe("SukkoClient", () => {
 
 			client.disconnect();
 		});
+
+		it("does not include unsubscribed channels in last_pos", async () => {
+			const { client, transport } = createClient();
+			client.connect();
+			await vi.advanceTimersByTimeAsync(0);
+
+			// Receive pos on two channels
+			transport.simulateMessage({
+				type: "message",
+				seq: 1,
+				ts: Date.now(),
+				channel: "tenant.BTC.trade",
+				data: {},
+				pos: "2-50",
+			});
+			transport.simulateMessage({
+				type: "message",
+				seq: 2,
+				ts: Date.now(),
+				channel: "tenant.ETH.trade",
+				data: {},
+				pos: "3-99",
+			});
+
+			// Unsubscribe from BTC
+			client.unsubscribe(["tenant.BTC.trade"]);
+			client.reconnectWithReplay();
+
+			const reconnectMsg = transport.sent.find((s) => JSON.parse(s).type === "reconnect");
+			expect(reconnectMsg).toBeDefined();
+			const parsed = JSON.parse(reconnectMsg!);
+			// Unsubscribed channel must not appear
+			expect(parsed.data.last_pos["tenant.BTC.trade"]).toBeUndefined();
+			// Still-subscribed channel must be present
+			expect(parsed.data.last_pos["tenant.ETH.trade"]).toBe("3-99");
+
+			client.disconnect();
+		});
 	});
 });

--- a/packages/svelte/tests/context.test.ts
+++ b/packages/svelte/tests/context.test.ts
@@ -21,7 +21,7 @@ class MockTransport extends TypedEventEmitter<TransportEvents> implements Transp
 }
 
 // Mock svelte context API
-let contextStore = new Map<unknown, unknown>();
+const contextStore = new Map<unknown, unknown>();
 
 vi.mock("svelte", () => ({
 	setContext: (key: unknown, value: unknown) => {

--- a/packages/svelte/tests/subscription.test.ts
+++ b/packages/svelte/tests/subscription.test.ts
@@ -1,5 +1,11 @@
 import { SukkoClient, TypedEventEmitter } from "@sukko/sdk";
-import type { DataMessage, Transport, TransportCapabilities, TransportEvents, TransportState } from "@sukko/sdk";
+import type {
+	DataMessage,
+	Transport,
+	TransportCapabilities,
+	TransportEvents,
+	TransportState,
+} from "@sukko/sdk";
 import { describe, expect, it, vi } from "vitest";
 
 class MockTransport extends TypedEventEmitter<TransportEvents> implements Transport {

--- a/packages/vue/src/context.ts
+++ b/packages/vue/src/context.ts
@@ -5,7 +5,6 @@ import {
 	type Plugin,
 	type Ref,
 	defineComponent,
-	h,
 	inject,
 	onMounted,
 	onUnmounted,
@@ -95,8 +94,7 @@ export function createSukkoPlugin(pluginOptions: SukkoPluginOptions): Plugin {
 				throw new Error("createSukkoPlugin requires either a 'client' or 'options'");
 			}
 			const client =
-				pluginOptions.client ??
-				new SukkoClient({ ...pluginOptions.options!, autoConnect: false });
+				pluginOptions.client ?? new SukkoClient({ ...pluginOptions.options!, autoConnect: false });
 			app.provide(SUKKO_KEY, client);
 		},
 	};

--- a/packages/vue/tests/context.test.ts
+++ b/packages/vue/tests/context.test.ts
@@ -1,8 +1,8 @@
 import { SukkoClient, TypedEventEmitter } from "@sukko/sdk";
 import type { Transport, TransportCapabilities, TransportEvents, TransportState } from "@sukko/sdk";
 import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
 import { defineComponent, h } from "vue";
-import { afterEach, describe, expect, it, vi } from "vitest";
 import { SukkoProvider, useSukkoClient } from "../src/context";
 
 class MockTransport extends TypedEventEmitter<TransportEvents> implements Transport {

--- a/packages/vue/tests/use-connection.test.ts
+++ b/packages/vue/tests/use-connection.test.ts
@@ -1,10 +1,10 @@
 import { SukkoClient, TypedEventEmitter } from "@sukko/sdk";
 import type { Transport, TransportCapabilities, TransportEvents, TransportState } from "@sukko/sdk";
 import { mount } from "@vue/test-utils";
-import { defineComponent, h, nextTick } from "vue";
 import { describe, expect, it } from "vitest";
-import { SukkoProvider } from "../src/context";
+import { defineComponent, h, nextTick } from "vue";
 import { useConnectionState } from "../src/composables/use-connection";
+import { SukkoProvider } from "../src/context";
 
 class MockTransport extends TypedEventEmitter<TransportEvents> implements Transport {
 	private _state: TransportState = "closed";

--- a/packages/vue/tests/use-subscription.test.ts
+++ b/packages/vue/tests/use-subscription.test.ts
@@ -1,10 +1,16 @@
 import { SukkoClient, TypedEventEmitter } from "@sukko/sdk";
-import type { DataMessage, Transport, TransportCapabilities, TransportEvents, TransportState } from "@sukko/sdk";
+import type {
+	DataMessage,
+	Transport,
+	TransportCapabilities,
+	TransportEvents,
+	TransportState,
+} from "@sukko/sdk";
 import { mount } from "@vue/test-utils";
-import { defineComponent, h, nextTick } from "vue";
 import { describe, expect, it, vi } from "vitest";
-import { SukkoProvider } from "../src/context";
+import { defineComponent, h, nextTick } from "vue";
 import { useSubscription } from "../src/composables/use-subscription";
+import { SukkoProvider } from "../src/context";
 
 class MockTransport extends TypedEventEmitter<TransportEvents> implements Transport {
 	private _state: TransportState = "closed";

--- a/packages/websocket/src/transport.ts
+++ b/packages/websocket/src/transport.ts
@@ -30,10 +30,7 @@ const DEFAULT_CONNECTION_TIMEOUT = 10000;
  * });
  * ```
  */
-export class WebSocketTransport
-	extends TypedEventEmitter<TransportEvents>
-	implements Transport
-{
+export class WebSocketTransport extends TypedEventEmitter<TransportEvents> implements Transport {
 	private ws: WebSocket | null = null;
 	private token: string;
 	private readonly url: string;
@@ -151,10 +148,7 @@ export class WebSocketTransport
 			this.ws.onclose = null;
 			this.ws.onerror = null;
 			this.ws.onmessage = null;
-			if (
-				this.ws.readyState === WebSocket.OPEN ||
-				this.ws.readyState === WebSocket.CONNECTING
-			) {
+			if (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING) {
 				this.ws.close(code ?? 1000, reason ?? "");
 			}
 			this.ws = null;

--- a/packages/websocket/src/types.ts
+++ b/packages/websocket/src/types.ts
@@ -1,5 +1,8 @@
 /** WebSocket constructor type for dependency injection. */
-export type WebSocketConstructor = new (url: string | URL, protocols?: string | string[]) => WebSocket;
+export type WebSocketConstructor = new (
+	url: string | URL,
+	protocols?: string | string[],
+) => WebSocket;
 
 /** Options for creating a WebSocketTransport. */
 export interface WebSocketTransportOptions {

--- a/scripts/generate-token.ts
+++ b/scripts/generate-token.ts
@@ -1,5 +1,5 @@
-import { SignJWT } from "jose";
 import { parseArgs } from "node:util";
+import { SignJWT } from "jose";
 
 const { values } = parseArgs({
 	options: {
@@ -12,7 +12,9 @@ const { values } = parseArgs({
 });
 
 if (!values.sub || !values.tenant) {
-	console.error("Usage: bun run token --sub <principal> --tenant <tenant_id> [--groups g1,g2] [--secret key] [--exp 1h]");
+	console.error(
+		"Usage: bun run token --sub <principal> --tenant <tenant_id> [--groups g1,g2] [--secret key] [--exp 1h]",
+	);
 	process.exit(1);
 }
 


### PR DESCRIPTION
## Summary

- `DataMessage` now exposes `pos?: string` — the opaque Kafka replay cursor sent by the server on all Kafka-backed messages
- `reconnectWithReplay()` now sends `last_pos: Record<string, string>` (string pos values) instead of the old `last_offset: Record<string, number>` (numeric seq values), aligning with the server's protocol after `refactor/history-unified-pos-cursor`
- SDK tracks `msg.pos` per channel automatically; `reconnectWithReplay()` is a no-op when no pos values have been tracked (Direct backend or fresh session)

**Why this matters**: the old `last_offset` field was silently ignored by the server (which now reads `last_pos`), causing reconnect replay to never work. This fix closes the protocol mismatch.

Companion PRs:
- klurvio/sukko#133 — AsyncAPI spec corrections
- klurvio/sukko-docs#13 — SDK guide documentation

## Test plan

- [ ] All 131 tests pass (`bun run test`)
- [ ] Lint clean on changed files (`bun run biome check packages/sdk/...`)
- [ ] `reconnectWithReplay()` sends `last_pos` with string pos values after receiving a message with `pos`
- [ ] `reconnectWithReplay()` is a no-op when no `pos` values tracked (Direct backend messages have no `pos`)
- [ ] Multi-channel: only channels with `pos` appear in `last_pos`